### PR TITLE
Add local styledocco dependency and options.cmd

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -29,6 +29,7 @@ module.exports = (grunt) ->
       test:
         options:
           name: "<%= pkg.name %> v<%= pkg.version %>"
+          cmd: "node_modules/.bin/styledocco"
         files: [
           "test/tmp": "test/fixtures"
         ]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ grunt.loadNpmTasks('grunt-styledocco');
 >
 > The previews are rendered in a resizable iframes to make it easy to demonstrate responsive designs at different viewport sizes.
 
-This task requires you to have [StyleDocco](https://github.com/jacobrask/styledocco) installed globally. Run `npm install -g styledocco` to install it.
+If you don't have a global install of [StyleDocco](https://github.com/jacobrask/styledocco) which can be achieved by `npm install -g styledocco` , you need to specify options.cmd to the binary you want to use.
 
 ### Options
 
@@ -57,6 +57,13 @@ Type: `String`
 Default value: `null`
 
 A custom preprocessor command (ex: `"~/bin/lessc"`).
+
+#### options.cmd
+
+Type: `String`
+Default value: `styledocco`
+
+A custom Styledocco command (ex: `"./node_modules/.bin/styledocco"`).
 
 #### options.verbose
 

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "sass",
     "scss",
     "css"
-  ]
+  ],
+  "dependencies": {
+    "styledocco": "^0.6.6"
+  }
 }

--- a/tasks/styledocco.coffee
+++ b/tasks/styledocco.coffee
@@ -20,6 +20,7 @@ module.exports = (grunt) ->
 
     options = @options(
       name: "Styledocco"
+      cmd: "styledocco"
       include: null
       preprocessor: null
     )
@@ -27,7 +28,7 @@ module.exports = (grunt) ->
     @files.forEach (file) ->
       args = []
       command =
-        cmd: "styledocco"
+        cmd: options.cmd
         args: args
 
       args.push file.src[0]


### PR DESCRIPTION
Now you can set options.cmd to a binary. This enables projects to add styledocco as a local dependency and use this instead of having a global installation.
